### PR TITLE
Fix Url in package header

### DIFF
--- a/prettier-js.el
+++ b/prettier-js.el
@@ -33,7 +33,7 @@
 
 ;; Author: James Long and contributors
 ;; Created: 10 January 2017
-;; Url: https://github.com/prettier/prettier/blob/master/editors/emacs/prettier-js.el
+;; Url: https://github.com/prettier/prettier-emacs
 ;; Keywords: convenience wp edit js
 
 ;; This file is not part of GNU Emacs.


### PR DESCRIPTION
When I click the old one, I get a 404 error.