### PR TITLE
Correct use of unwind-protect

### DIFF
--- a/prettier-js.el
+++ b/prettier-js.el
@@ -193,11 +193,11 @@ a `before-save-hook'."
              (message "Could not apply prettier")
              (if errbuf
                  (prettier-js--process-errors (buffer-file-name) bufferfile errorfile errbuf))
-             )))
-     (kill-buffer patchbuf)
-     (delete-file errorfile)
-     (delete-file bufferfile)
-     (delete-file outputfile)))
+             ))
+       (kill-buffer patchbuf)
+       (delete-file errorfile)
+       (delete-file bufferfile)
+       (delete-file outputfile))))
 
 ;;;###autoload
 (define-minor-mode prettier-js-mode


### PR DESCRIPTION
Prevents leaking of temp files

```
juergen@samson:~ → ls -ltrc /tmp/prettier17296*
-rw------- 1 juergen juergen 682 12. Jun 13:11 /tmp/prettier17296Rg1.json
-rw------- 1 juergen juergen   0 12. Jun 13:11 /tmp/prettier17296Q0K.json
-rw------- 1 juergen juergen   0 12. Jun 13:11 /tmp/prettier17296DqE.json

```