### PR TITLE
Pass `bufferfile' on stdin and `buffer-file-name' as target

### DIFF
--- a/prettier-js.el
+++ b/prettier-js.el
@@ -182,8 +182,8 @@ a `before-save-hook'."
            (with-current-buffer patchbuf
              (erase-buffer))
            (if (zerop (apply 'call-process
-                             prettier-js-command nil (list (list :file outputfile) errorfile)
-                             nil (append (append prettier-js-args width-args) (list bufferfile))))
+                             prettier-js-command bufferfile (list (list :file outputfile) errorfile)
+                             nil (append (append prettier-js-args width-args (list "--stdin")) (list buffer-file-name))))
                (progn
                  (call-process-region (point-min) (point-max) "diff" nil patchbuf nil "-n" "-"
                                       outputfile)


### PR DESCRIPTION
This allows the use of `prettier-eslint-cli` as a drop-in replacement:

```
(setq prettier-js-command "prettier-eslint")
```

See also https://github.com/prettier/prettier-eslint-cli/issues/37#issuecomment-312536618