### PR TITLE
Fix support for non-js files

### DIFF
--- a/prettier-js.el
+++ b/prettier-js.el
@@ -183,7 +183,7 @@ a `before-save-hook'."
              (erase-buffer))
            (if (zerop (apply 'call-process
                              prettier-js-command bufferfile (list (list :file outputfile) errorfile)
-                             nil (append (append prettier-js-args width-args (list "--stdin")) (list buffer-file-name))))
+                             nil (append prettier-js-args width-args (list "--stdin" "--stdin-filepath" buffer-file-name))))
                (progn
                  (call-process-region (point-min) (point-max) "diff" nil patchbuf nil "-n" "-"
                                       outputfile)


### PR DESCRIPTION
`--stdin-filepath` is necessary for parser inference to work. This fixes
Typescript/json/css/etc support.