### PR TITLE
Fix type of defcustom prettier-js-args

### DIFF
--- a/prettier-js.el
+++ b/prettier-js.el
@@ -56,7 +56,7 @@
 
 (defcustom prettier-js-args '()
   "List of args to send to prettier command."
-  :type 'list
+  :type '(repeat string)
   :group 'prettier-js)
 
 (defcustom prettier-js-show-errors 'buffer


### PR DESCRIPTION
This lets you insert arguments for the command using customize