### PR TITLE
update readme with prettier requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,17 @@ package also exports a minor mode that applies `(prettier-js)` on save.
 
 ## Configuration
 
+### Requirements
+
+Ensure that the prettier program is installed:
+
+```bash
+which prettier
+```
+
+If prettier is not installed already, you can install prettier using `npm -g prettier` or via your package manager.
+
+
 ### Basic configuration
 
 First require the package:


### PR DESCRIPTION

This PR clarifies the requirements in the readme to ensure that Prettier is installed. 

While setting this up, I wasn't aware that `prettier` needed to be installed globally, so my code wasn't getting prettified on save. Eventually, I checked my Messages buffer and found this error:

>Error: (file-error "Searching for program" "No such file or directory" "prettier")

So I installed Prettier and everything is working :-)

I think others may benefit from a little clarification that this package requires Prettier to be installed separately.