### PR TITLE
Allow for TRAMP configuration

### DIFF
--- a/prettier-js.el
+++ b/prettier-js.el
@@ -164,6 +164,7 @@ a `before-save-hook'."
           (patchbuf (get-buffer-create "*prettier patch*"))
           (coding-system-for-read 'utf-8)
           (coding-system-for-write 'utf-8)
+          (localname (or (file-remote-p buffer-file-name 'localname) buffer-file-name))
           (width-args
            (cond
             ((equal prettier-js-width-mode 'window)
@@ -184,7 +185,7 @@ a `before-save-hook'."
              (erase-buffer))
            (if (zerop (apply 'call-process
                              prettier-js-command bufferfile (list (list :file outputfile) errorfile)
-                             nil (append prettier-js-args width-args (list "--stdin" "--stdin-filepath" buffer-file-name))))
+                             nil (append prettier-js-args width-args (list "--stdin" "--stdin-filepath" localname))))
                (progn
                  (call-process-region (point-min) (point-max) "diff" nil patchbuf nil "-n" "--strip-trailing-cr" "-"
                                       outputfile)


### PR DESCRIPTION
This patch is necessary to allow prettier-emacs to be configured using TRAMP.  If the buffer being saved is a remote file, it has a preamble that looks something like `/ssh:example.com:/path/to/file`.  These changes strip that preamble and pass just the file path to the `prettier` command.

In my setup, I have ssh keys set up between my development machine and the server on which the code and the `prettier` executable live.  My prettier-emacs config looks something like this:

```
(setq prettier-js-command "ssh")
(setq prettier-js-args '("example.com" "prettier"))
```

This configuration, in conjunction with this patch, causes things to work as expected.
