### PR TITLE
Sync Prettier options to buffer-local variables

### DIFF
--- a/OptionsPlugin.js
+++ b/OptionsPlugin.js
@@ -1,0 +1,31 @@
+/*
+ * A plugin that simply outputs all Prettier options serialized as
+ * JSON. It ignores all input, except that it's never called when
+ * input is empty.
+ */
+
+const parserName = 'optionsPrinter';
+const astFormat = `${parserName}-ast`;
+const languageName = parserName;
+
+module.exports = {
+  languages: [{
+    name: languageName,
+    parsers: [parserName]
+  }],
+  parsers: {
+    [parserName]: {
+      parse: () => ({}),
+      astFormat,
+      locStart: () => 0,
+      locEnd: () => 0
+    }
+  },
+  options: {},
+  defaultOptions: {},
+  printers: {
+    [astFormat]: {
+      print: (path, options, print) => JSON.stringify(options)
+    }
+  }
+}


### PR DESCRIPTION
This syncs various Prettier options, such as `printWidth` and `useTabs`, to the corresponding Emacs variables, such as `js-indent-level`.

Emacs variables are set for a number of major modes for languages that Prettier supports either directly or through plug-ins.

Buffer-local variables are removed or restored to their previous value when `prettier-js-mode` is disabled, unless the variable was changed since `prettier-js-mode` was enabled.
