### PR TITLE
Add autoload cookie for prettier-js

### DIFF
--- a/prettier-js.el
+++ b/prettier-js.el
@@ -153,6 +153,7 @@ a `before-save-hook'."
         (erase-buffer))
       (kill-buffer errbuf))))
 
+;;;###autoload
 (defun prettier-js ()
    "Format the current buffer according to the prettier tool."
    (interactive)


### PR DESCRIPTION
I never use `prettier-mode` but always manually call `prettier-js`.

This adds an autoload cookie for this command so it's available when the library is not loaded yet.