### PR TITLE
Update README.md with Windows Installation Notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,15 @@ And then hook to web-mode like this:
                             (enable-minor-mode
                              '("\\.jsx?\\'" . prettier-js-mode))))
 ```
+## Installing on Windows
+
+This package requires the `diff` tool which is already included on Unix platforms. The simplest way to install `diff` on Windows is to use [Chocolatey](https://chocolatey.org/). The steps are as follows:
+
+1. Follow the Chocolatey install instructions: https://chocolatey.org/install
+2. Open an Admin Powershell session
+3. Install the `diff` program: `choco install diffutils`
+
+You should now be able to open Emacs and successfully use this package.
 
 ## Customization
 


### PR DESCRIPTION
Windows users need to do an additional step of installing `diff`.  The steps required to do that are now explained in the readme.