### PR TITLE
Allow specifying diff program

### DIFF
--- a/prettier-js.el
+++ b/prettier-js.el
@@ -54,6 +54,11 @@
   :type 'string
   :group 'prettier-js)
 
+(defcustom prettier-js-diff-command "diff"
+  "The 'diff' command for generating RCS diff."
+  :type 'string
+  :group 'prettier-js)
+
 (defcustom prettier-js-args '()
   "List of args to send to prettier command."
   :type '(repeat string)
@@ -186,7 +191,7 @@ a `before-save-hook'."
                              prettier-js-command bufferfile (list (list :file outputfile) errorfile)
                              nil (append prettier-js-args width-args (list "--stdin" "--stdin-filepath" buffer-file-name))))
                (progn
-                 (call-process-region (point-min) (point-max) "diff" nil patchbuf nil "-n" "--strip-trailing-cr" "-"
+                 (call-process-region (point-min) (point-max) prettier-js-diff-command nil patchbuf nil "-n" "--strip-trailing-cr" "-"
                                       outputfile)
                  (prettier-js--apply-rcs-patch patchbuf)
                  (message "Applied prettier with args `%s'" prettier-js-args)


### PR DESCRIPTION
On some systems such as OpenBSD, the `diff` program does not support some of the features available under GNU diff, e.g. `--strip-trailing-cr`. AFAIK, there's no way to reproduce the behavior of `--strip-trailing-cr` without piping to `tr` or `sed` (which is probably not ideal).

So I think it might make sense to allow specifying diff program, so I can install `gdiff` and configure prettier-emacs to use it. This PR basically add `prettier-js-diff-command` to defcustom, and use it in place of the existing `diff` string. 

Thanks!