### PR TITLE
fix #77: prettier-js cleanse the code

### DIFF
--- a/prettier-js.el
+++ b/prettier-js.el
@@ -183,8 +183,8 @@ a `before-save-hook'."
            (with-current-buffer patchbuf
              (erase-buffer))
            (if (zerop (apply 'call-process
-                             prettier-js-command bufferfile (list (list :file outputfile) errorfile)
-                             nil (append prettier-js-args width-args (list "--stdin" "--stdin-filepath" buffer-file-name))))
+                             prettier-js-command nil (list (list :file outputfile) errorfile)
+                             nil (append prettier-js-args (list bufferfile) width-args (list "--stdin" "--stdin-filepath" buffer-file-name))))
                (progn
                  (call-process-region (point-min) (point-max) "diff" nil patchbuf nil "-n" "--strip-trailing-cr" "-"
                                       outputfile)


### PR DESCRIPTION
## Problem

See the issue #77 

## Brief Analysis

After debugging the procedure, it is found that the `call-process` calls `prettier` with arguments with outputting to temporary files before doing patching. Original implementation is to input code content to `prettier` via standard input, however somehow it does not work under win11/powershell. When putting the code file as argument, the reformat is working (e.g. `prettier xxx.js`).

## Test Coverage

Only tested on Win11. Environment can be found in issue #77 as well.