### PR TITLE
Add use-package example

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ First require the package:
 (require 'prettier-js)
 ```
 
+Or use `use-package` (available in Emacs 29.1 and above):
+
+```elisp
+(use-package prettier-js)
+```
+
 Then you can hook to your favorite javascript mode:
 
 ```elisp


### PR DESCRIPTION
Like https://github.com/prettier/prettier-emacs/pull/57, except don't include the link to the old use-package repo, since most users shouldn't need to install that since use-package is included in recent versions of Emacs.