### PR TITLE
Fix compilation warnings

### DIFF
--- a/prettier-js.el
+++ b/prettier-js.el
@@ -1,4 +1,4 @@
-;;; prettier-js.el --- Minor mode to format JS code on file save
+;;; prettier-js.el --- Minor mode to format JS code on file save  -*- lexical-binding: t; -*-
 
 ;; Version: 0.1.0
 

--- a/prettier-js.el
+++ b/prettier-js.el
@@ -50,12 +50,12 @@
   :link '(url-link :tag "Repository" "https://github.com/prettier/prettier"))
 
 (defcustom prettier-js-command "prettier"
-  "The 'prettier' command."
+  "The `prettier' command."
   :type 'string
   :group 'prettier-js)
 
 (defcustom prettier-js-diff-command "diff"
-  "The 'diff' command for generating RCS diff."
+  "The `diff' command for generating RCS diff."
   :type 'string
   :group 'prettier-js)
 
@@ -134,7 +134,7 @@ a `before-save-hook'."
               (error "Invalid rcs patch or internal error in prettier-js--apply-rcs-patch")))))))))
 
 (defun prettier-js--process-errors (filename errorfile errbuf)
-  "Process errors for FILENAME, using an ERRORFILE and display the output in ERRBUF."
+  "Process errors for FILENAME, using ERRORFILE, displaying the output in ERRBUF."
   (with-current-buffer errbuf
     (if (eq prettier-js-show-errors 'echo)
         (progn


### PR DESCRIPTION
I noticed when installing the package that there were a number of compilation warnings.  While these don't necessarily indicate a problem with the package, they create a bit of unnecessary noise for users depending on how they install the package.

I like to install my packages via a script that I run with `emacs --script`.  In this case the compilation warnings pop up quite visibly.  This might reduce users' confidence in the package slightly:

<img width="731" alt="Screenshot 2025-06-23 at 5 17 13 PM" src="https://github.com/user-attachments/assets/9250c90a-15f8-4178-b57f-7424b3f18bfa" />

The warnings can also be seen in the `*Compile-Log*` buffer when installing via `package-install` or `package-list-packages`:

<img width="978" alt="Screenshot 2025-06-23 at 5 16 17 PM" src="https://github.com/user-attachments/assets/1bececc4-ae76-4dc9-b442-f51254f96536" />

Or if a maintainer uses Flycheck the warnings show up with `flycheck-list-errors`:

<img width="1043" alt="Screenshot 2025-06-23 at 5 28 52 PM" src="https://github.com/user-attachments/assets/c02d3279-5b7e-4778-8bcc-f3429ef86bc7" />

Anyway, I cleaned up the code to fix the warnings.  I consulted an LLM to try and find any risks with enabling Lexical Binding and it reported none:

> After reviewing the code, I don't see any issues that would prevent adding lexical binding. The code:
>
> 1. Doesn't rely on dynamic binding for any variables
> 2. Properly defines all variables used within functions
> 3. Doesn't use any special forms that would behave differently under lexical binding
> 4. Doesn't access variables from outer scopes without proper passing
>
> All functions properly define their local variables using `let` and `let*`, and there are no cases where functions access variables from outer scopes without those variables being passed as parameters.
>
> No code refactoring is needed to support lexical binding in this file.

My own review of the code also confirms this.  I tried formatting code and that still seems to work too.

I used `package-install-file` to install the package and it doesn't report those warnings any more:

<img width="767" alt="Screenshot 2025-06-23 at 5 19 55 PM" src="https://github.com/user-attachments/assets/d2297922-499d-4b3c-a854-acd6a865f8cf" />

(I think there's a bug with the functions that install local packages, where they raise a compilation warning on generated files like `*-pkg.el`.  Since that error doesn't occur with packages from MELPA, I think the log will be completely clear in the ordinary installation case.)

ping @jcs090218 and @fisker to review/merge