### PR TITLE
Add setup instructions for BSD users

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,20 @@ This package requires the `diff` tool which is already included on Unix platform
 
 You should now be able to open Emacs and successfully use this package.
 
+## BSD Users
+
+On BSD systems (like OpenBSD, FreeBSD), the default `diff` program may not support some GNU diff features that prettier-js requires, such as `--strip-trailing-cr`. To resolve this:
+
+1. Install GNU diff (often called `gdiff` or `gnudiff`):
+   - On OpenBSD: `pkg_add gdiff`
+   - On FreeBSD: `pkg install diffutils`
+
+2. Configure prettier-js to use the GNU diff implementation:
+   ```elisp
+   (setq prettier-js-diff-command "gdiff")
+   ```
+   (Use the appropriate command name for your system, which might be `gdiff`, `gnudiff`, or `gd`)
+
 ## Customization
 
 This package is customizable via custom.el:


### PR DESCRIPTION
Follow-up to: https://github.com/prettier/prettier-emacs/pull/56

I thought it would be helpful to provide setup instructions for BSD users.  Even though we provided that config option to help them, setup still wouldn't be plug-and-play for them.  They'd need to dig through closed issues and find that thread.

Disclaimer: I haven't used BSD, but I believe I found the right packages:

- https://openbsd.app/?search=gdiff
- https://ports.freebsd.org/cgi/ports.cgi?query=diffutils&stype=all&sektion=all

Maybe @sirn can confirm if these instructions look correct?

As mentioned [here](https://github.com/prettier/prettier-emacs/pull/52#issuecomment-471604303), a more portable alternative would be to remove the dependency and diff in elisp.  Not sure of the scope on that though.