### PR TITLE
Initialize ERT tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,14 @@ jobs:
       with:
         version: 'snapshot'
 
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: '22.x'
+
+    - name: Install prettier
+      run: npm install -g prettier
+
     - name: Build
       run: |
         eask package
@@ -55,3 +63,7 @@ jobs:
     - name: Run linter
       run: |
         eask lint checkdoc
+
+    - name: Run tests
+      run: |
+        eask test ert prettier-js-test.el

--- a/fixtures/clean.js
+++ b/fixtures/clean.js
@@ -1,0 +1,14 @@
+function messy(a, b) {
+  return a + b + 100;
+}
+
+const obj = {
+  foo: "bar",
+  baz: 42,
+  qux: [1, 2, 3],
+};
+
+// This is a messy JavaScript file
+if (true) {
+  console.log("hello world");
+}

--- a/fixtures/dirty.js
+++ b/fixtures/dirty.js
@@ -1,0 +1,14 @@
+function messy(a,b)
+{
+    return a+b
+    +100;
+}
+
+const obj = {
+    foo:"bar",
+    baz:  42,
+  qux:[1,2, 3]
+};
+
+// This is a messy JavaScript file
+if(true){console.log("hello world")}

--- a/fixtures/project/package-lock.json
+++ b/fixtures/project/package-lock.json
@@ -1,0 +1,31 @@
+{
+  "name": "prettier-test-project",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "prettier-test-project",
+      "version": "1.0.0",
+      "devDependencies": {
+        "prettier": "^3.0.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.0.tgz",
+      "integrity": "sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    }
+  }
+}

--- a/fixtures/project/package.json
+++ b/fixtures/project/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "prettier-test-project",
+  "version": "1.0.0",
+  "description": "Test project for prettier-js",
+  "devDependencies": {
+    "prettier": "^3.0.0"
+  }
+}

--- a/fixtures/project/src/messy.js
+++ b/fixtures/project/src/messy.js
@@ -1,0 +1,14 @@
+function messy(a,b)
+{
+    return a+b
+    +100;
+}
+
+const obj = {
+    foo:"bar",
+    baz:  42,
+  qux:[1,2, 3]
+};
+
+// This is a messy JavaScript file
+if(true){console.log("hello world")}

--- a/prettier-js-test.el
+++ b/prettier-js-test.el
@@ -1,0 +1,43 @@
+;;; prettier-js-test.el --- Tests for prettier-js  -*- lexical-binding: t; -*-
+
+;; Copyright (c) 2025 The prettier-js Authors. All rights reserved.
+
+;;; Commentary:
+;; Tests for prettier-js.el
+
+;;; Code:
+
+(require 'ert)
+(require 'prettier-js)
+
+(ert-deftest prettier-js-test-formatting ()
+  "Test that prettier-js correctly formats JavaScript code."
+  (let* ((dirty-file (expand-file-name "fixtures/dirty.js"))
+         (clean-file (expand-file-name "fixtures/clean.js"))
+         (temp-file (make-temp-file "prettier-test-" nil ".js")))
+    (unwind-protect
+        (progn
+          ;; Copy dirty content to temp file
+          (copy-file dirty-file temp-file t)
+
+          ;; Visit the temp file
+          (with-current-buffer (find-file-noselect temp-file)
+            ;; Format the buffer
+            (prettier-js)
+
+            ;; Get the expected clean content
+            (let ((expected-content
+                   (with-temp-buffer
+                     (insert-file-contents clean-file)
+                     (buffer-string)))
+                  (actual-content (buffer-string)))
+              ;; Compare the formatted content with the expected clean content
+              (should (string= actual-content expected-content))
+              (kill-buffer))))
+
+      ;; Clean up temp file
+      (when (file-exists-p temp-file)
+        (delete-file temp-file)))))
+
+(provide 'prettier-js-test)
+;;; prettier-js-test.el ends here

--- a/prettier-js-test.el
+++ b/prettier-js-test.el
@@ -9,6 +9,29 @@
 
 (require 'ert)
 (require 'prettier-js)
+(require 'files)
+(require 'subr-x)
+
+(defun prettier-js-test--copy-directory (source destination)
+  "Copy SOURCE directory to DESTINATION recursively."
+  (if (file-directory-p source)
+      (progn
+        (make-directory destination t)
+        (let ((files (directory-files source t)))
+          (dolist (file files)
+            (let ((name (file-name-nondirectory file)))
+              (unless (or (string= name ".") (string= name ".."))
+                (let ((dest-file (expand-file-name name destination)))
+                  (if (file-directory-p file)
+                      (prettier-js-test--copy-directory file dest-file)
+                    (copy-file file dest-file t))))))))
+    (copy-file source destination t)))
+
+(defun prettier-js-test--run-process (program &rest args)
+  "Run PROGRAM with ARGS in the current directory."
+  (let ((exit-code (apply #'call-process program nil nil nil args)))
+    (unless (= exit-code 0)
+      (error "Process %s exited with code %d" program exit-code))))
 
 (ert-deftest prettier-js-test-formatting ()
   "Test that prettier-js correctly formats JavaScript code."
@@ -38,6 +61,43 @@
       ;; Clean up temp file
       (when (file-exists-p temp-file)
         (delete-file temp-file)))))
+
+(ert-deftest prettier-js-test-node-modules ()
+  "Test that prettier-js can use the local node_modules/.bin/prettier."
+  (let* ((project-dir (expand-file-name "fixtures/project"))
+         (temp-dir (make-temp-file "prettier-project-" t))
+         (temp-src-dir (expand-file-name "src" temp-dir))
+         (temp-src-file (expand-file-name "messy.js" temp-src-dir))
+         (clean-file (expand-file-name "fixtures/clean.js"))
+         (default-directory temp-dir)
+         (prettier-js-use-modules-bin t))
+    (unwind-protect
+        (progn
+          ;; Copy project to temp directory
+          (prettier-js-test--copy-directory project-dir temp-dir)
+
+          ;; Install dependencies
+          (message "Installing npm dependencies in %s..." temp-dir)
+          (prettier-js-test--run-process "npm" "install")
+
+          ;; Visit the messy file
+          (with-current-buffer (find-file-noselect temp-src-file)
+            ;; Format the buffer using node_modules/.bin/prettier
+            (prettier-js)
+
+            ;; Get the expected clean content
+            (let ((expected-content
+                   (with-temp-buffer
+                     (insert-file-contents clean-file)
+                     (buffer-string)))
+                  (actual-content (buffer-string)))
+              ;; Compare the formatted content with the expected clean content
+              (should (string= actual-content expected-content))
+              (kill-buffer))))
+
+      ;; Clean up temp directory
+      (when (file-exists-p temp-dir)
+        (delete-directory temp-dir t)))))
 
 (provide 'prettier-js-test)
 ;;; prettier-js-test.el ends here

--- a/prettier-js.el
+++ b/prettier-js.el
@@ -183,9 +183,12 @@ Otherwise, return nil."
 Search starts from the current directory and moves up until found.
 Returns the path to the executable if found, nil otherwise."
   (let ((dir (expand-file-name default-directory))
-        (prettier-path nil))
+        (prettier-path nil)
+        (executable-name (if (eq system-type 'windows-nt)
+                             "prettier.cmd"
+                           "prettier")))
     (while (and dir (not prettier-path))
-      (let ((candidate (expand-file-name "node_modules/.bin/prettier" dir)))
+      (let ((candidate (expand-file-name (concat "node_modules/.bin/" executable-name) dir)))
         (if (file-executable-p candidate)
             (setq prettier-path candidate)
           (let ((parent (file-name-directory (directory-file-name dir))))


### PR DESCRIPTION
- Add tests for core functionality
- Fix `prettier-js-use-modules-bin` on Windows (an issue revealed by running the tests across platforms)
- Ensure that we see failing tests in PRs
- Enable setting to block merges to `master` when a PR has any failing tests