### PR TITLE
Diff dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,20 @@
-# Prettier-js for Emacs
+# prettier-js for Emacs
 
 [![MELPA](http://melpa.org/packages/prettier-js-badge.svg)](http://melpa.org/#/prettier-js) [![CI](https://github.com/prettier/prettier-emacs/actions/workflows/test.yml/badge.svg)](https://github.com/prettier/prettier-emacs/actions/workflows/test.yml)
 
-prettier-js is a function that formats the current buffer using [prettier](https://github.com/prettier/prettier). The
-package also exports a minor mode that applies `(prettier-js)` on save.
+This Emacs package provides a function, `prettier-js`, which formats the current buffer using [Prettier](https://github.com/prettier/prettier). It also exports a minor mode, `prettier-js-mode`, which calls `prettier-js` on save.
 
 ## Configuration
 
 ### Requirements
 
-Ensure that the prettier program is installed:
+Ensure that the `prettier` program is installed:
 
 ```bash
 which prettier
 ```
 
-If prettier is not installed already, you can install prettier using `npm install -g prettier` or via your package manager.
-
+If `prettier` is not installed already, you can install it using `npm install -g prettier` or via your package manager.
 
 ### Basic configuration
 
@@ -32,17 +30,16 @@ Or use `use-package` (available in Emacs 29.1 and above):
 (use-package prettier-js)
 ```
 
-Then you can hook to your favorite javascript mode:
+Then you can hook into your favorite JavaScript mode:
 
 ```elisp
 (add-hook 'js2-mode-hook 'prettier-js-mode)
 (add-hook 'web-mode-hook 'prettier-js-mode)
-...
 ```
 
 ### Prettier arguments
 
-To adjust the CLI args used for the prettier command, you can customize the `prettier-js-args` variable:
+To adjust the CLI args used for the `prettier` command, you can customize the `prettier-js-args` variable:
 
 ```elisp
 (setq prettier-js-args '(
@@ -53,23 +50,25 @@ To adjust the CLI args used for the prettier command, you can customize the `pre
 
 ### Usage with web-mode
 
-Web-mode is a popular mode for editing .js and .jsx files, but it is used to edit other template files too. If you want to hook prettier-js to web-mode for .js and .jsx files only, you can define a helper function like this:
+`web-mode` is a popular mode for editing `.js` and `.jsx` files, but it is used to edit other template files too. If you want to hook `prettier-js-mode` into `web-mode` for `.js` and `.jsx` files only, you can define a helper function like this:
 
 ```elisp
 (defun enable-minor-mode (my-pair)
-  "Enable minor mode if filename match the regexp.  MY-PAIR is a cons cell (regexp . minor-mode)."
+  "Enable minor mode if filename match the regexp.
+MY-PAIR is a cons cell (regexp . minor-mode)."
   (if (buffer-file-name)
       (if (string-match (car my-pair) buffer-file-name)
-      (funcall (cdr my-pair)))))
+          (funcall (cdr my-pair)))))
 ```
 
-And then hook to web-mode like this:
+And then hook into `web-mode` like this:
 
 ```elisp
 (add-hook 'web-mode-hook #'(lambda ()
                             (enable-minor-mode
                              '("\\.jsx?\\'" . prettier-js-mode))))
 ```
+
 ## Installing on Windows
 
 This package requires the `diff` tool which is already included on Unix platforms. The simplest way to install `diff` on Windows is to use [Chocolatey](https://chocolatey.org/). The steps are as follows:
@@ -96,14 +95,15 @@ On BSD systems (like OpenBSD, FreeBSD), the default `diff` program may not suppo
 
 ## Customization
 
-This package is customizable via custom.el:
+This package is customizable via Emacs' easy customization interface:
 
 ```
 M-x customize-group prettier-js
 ```
 
-* `prettier-js-command` is the prettier command
+* `prettier-js-command` is the `prettier` executable to use
+* `prettier-js-diff-command` is the `diff` executable to use
 * `prettier-js-args` are the args passed to the prettier command
-* `prettier-js-use-modules-bin` enables use of `node_modules/.bin/prettier` (your project's prettier version)
-* `prettier-js-show-errors` customizes where to display the error output (buffer, echo or nil)
-* `prettier-js-width-mode` customizes the width when formatting buffer contents (window, fill or nil)
+* `prettier-js-use-modules-bin` enables use of `node_modules/.bin/prettier` (your project's Prettier version)
+* `prettier-js-show-errors` customizes where to display the error output (`buffer`, `echo` or `nil`)
+* `prettier-js-width-mode` customizes the width when formatting buffer contents (`window`, `fill` or `nil`)

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ This Emacs package provides a function, `prettier-js`, which formats the current
 
 ### Requirements
 
+#### Have prettier installed
+
 Ensure that the `prettier` program is installed:
 
 ```bash
@@ -17,6 +19,35 @@ which prettier
 If `prettier` is not installed already, you can install it using `npm install -g prettier` or via your package manager.
 
 Alternatively, if your project uses Prettier (i.e. it's a `devDependency` in your `package.json`), then you'll be able to use the executable installed via `npm install`, instead.
+
+#### Have diff installed
+
+This package uses the `diff` program under the hood to reliably identify formatting changes made by Prettier.  On macOS and GNU/Linux, `diff` should already be installed.  On other platforms, you should install/configure GNU's diff implementation.
+
+<details><summary><b>Windows</b></summary>
+
+  On Windows, install via [Chocolatey](https://chocolatey.org/):
+
+  1. Follow the Chocolatey install instructions: https://chocolatey.org/install
+  2. Open an Admin PowerShell session
+  3. Install the `diff` program: `choco install diffutils`
+
+  Also, make sure that the correct version of `diff` is accessible from your system path; sometimes, multiple conflicting `diff` executables may be installed.
+</details>
+
+<details><summary><b>BSD systems (OpenBSD, FreeBSD)</b></summary>
+
+  On BSD systems (like OpenBSD, FreeBSD), the default `diff` program may not support some GNU diff features that this package requires, such as `--strip-trailing-cr`. To resolve this:
+
+  1. Install GNU diff (often called `gdiff` or `gnudiff`):
+     - On OpenBSD: `pkg_add gdiff`
+     - On FreeBSD: `pkg install diffutils`
+  2. Configure this package to use the GNU diff implementation:
+     ```elisp
+     (setq prettier-js-diff-command "gdiff")
+     ```
+     (Use the appropriate command name for your system, which might be `gdiff`, `gnudiff`, or `gd`)
+</details>
 
 ### Basic configuration
 
@@ -78,30 +109,6 @@ And then hook into `web-mode` like this:
                             (enable-minor-mode
                              '("\\.jsx?\\'" . prettier-js-mode))))
 ```
-
-## Installing on Windows
-
-This package requires the `diff` tool which is already included on Unix platforms. The simplest way to install `diff` on Windows is to use [Chocolatey](https://chocolatey.org/). The steps are as follows:
-
-1. Follow the Chocolatey install instructions: https://chocolatey.org/install
-2. Open an Admin Powershell session
-3. Install the `diff` program: `choco install diffutils`
-
-You should now be able to open Emacs and successfully use this package.
-
-## BSD Users
-
-On BSD systems (like OpenBSD, FreeBSD), the default `diff` program may not support some GNU diff features that prettier-js requires, such as `--strip-trailing-cr`. To resolve this:
-
-1. Install GNU diff (often called `gdiff` or `gnudiff`):
-   - On OpenBSD: `pkg_add gdiff`
-   - On FreeBSD: `pkg install diffutils`
-
-2. Configure prettier-js to use the GNU diff implementation:
-   ```elisp
-   (setq prettier-js-diff-command "gdiff")
-   ```
-   (Use the appropriate command name for your system, which might be `gdiff`, `gnudiff`, or `gd`)
 
 ## Customization
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ which prettier
 
 If `prettier` is not installed already, you can install it using `npm install -g prettier` or via your package manager.
 
+Alternatively, if your project uses Prettier (i.e. it's a `devDependency` in your `package.json`), then you'll be able to use the executable installed via `npm install`, instead.
+
 ### Basic configuration
 
 First require the package:
@@ -36,6 +38,14 @@ Then you can hook into your favorite JavaScript mode:
 (add-hook 'js2-mode-hook 'prettier-js-mode)
 (add-hook 'web-mode-hook 'prettier-js-mode)
 ```
+
+You can also enable use of your project's Prettier (instead of the system one):
+
+```elisp
+(setq prettier-js-use-modules-bin t)
+```
+
+This uses `node_modules/.bin/prettier`. Make sure to run `npm install` from your project directory so that the command is available there.
 
 ### Prettier arguments
 


### PR DESCRIPTION
The issue backlog indicates that users often have trouble with the `diff` dependency:

- https://github.com/prettier/prettier-emacs/issues/20
- https://github.com/prettier/prettier-emacs/issues/25

Adding notes on it to the readme was a good start, but I felt there was more we could do:

1. List it under the readme's "Requirements" section so the information is highlighted up-front
2. Add better error messaging to the package itself to try and help users who run into issues

Additionally, when I went to reorganize the information in the readme, I cleaned up the wording and formatting throughout it too, because it was bugging me (just a bit).  And I filled in some missing parts.

# Demo

<img width="798" alt="Screenshot 2025-07-02 at 7 11 51 PM" src="https://github.com/user-attachments/assets/87db3ab0-0891-49d3-b8ba-c659689d6e9a" />

<img width="809" alt="Screenshot 2025-07-02 at 7 12 51 PM" src="https://github.com/user-attachments/assets/37a60264-c36e-4302-b484-4cad3318514c" />

# Disclaimer

Haven't actually tested this with "bad" diff implementations.  However, according to ChatGPT, other popular implementations all use the same exit code pattern as GNU diff (>1 for errors), so I think the error detection mechanism I wrote should work.

<img width="795" alt="Screenshot 2025-07-02 at 7 24 55 PM" src="https://github.com/user-attachments/assets/48f8b72e-8bed-4837-9d91-3b21df9f9f04" />