### PR TITLE
Org support

### DIFF
--- a/fixtures/all-languages.org
+++ b/fixtures/all-languages.org
@@ -1,0 +1,96 @@
+#+TITLE: Test All Supported Languages
+#+AUTHOR: Prettier.js
+#+DATE: 2025-07-03
+
+* JavaScript
+#+BEGIN_SRC js
+function messy(a,b){return a+b;}
+const obj = { foo: "bar",baz: 42 };
+if(true){console.log("hello world");}
+#+END_SRC
+
+* TypeScript
+#+BEGIN_SRC ts
+function messy(a:number,b:number):number{return a+b;}
+const obj = { foo: "bar",baz: 42 };
+interface Person{name:string;age:number;}
+#+END_SRC
+
+* JSX
+#+BEGIN_SRC jsx
+function Component(){return(<div className="container"><h1>Hello,World!</h1><p>This is a paragraph.</p></div>);}
+#+END_SRC
+
+* TSX
+#+BEGIN_SRC tsx
+function Component():JSX.Element{return(<div className="container"><h1>Hello,World!</h1><p>This is a paragraph.</p></div>);}
+#+END_SRC
+
+* CSS
+#+BEGIN_SRC css
+.container{width:100%;max-width:1200px;margin:0 auto;padding:0 15px;}
+h1{font-size:2rem;color:#333;margin-bottom:1rem;}
+#+END_SRC
+
+* SCSS
+#+BEGIN_SRC scss
+$primary-color:#333;.container{width:100%;max-width:1200px;margin:0 auto;padding:0 15px;h1{font-size:2rem;color:$primary-color;margin-bottom:1rem;}}
+#+END_SRC
+
+* LESS
+#+BEGIN_SRC less
+@primary-color:#333;.container{width:100%;max-width:1200px;margin:0 auto;padding:0 15px;h1{font-size:2rem;color:@primary-color;margin-bottom:1rem;}}
+#+END_SRC
+
+* JSON
+#+BEGIN_SRC json
+{"name":"John Doe","age":30,"isActive":true,"address":{"street":"123 Main St","city":"Anytown","zip":"12345"},"hobbies":["reading","coding","hiking"]}
+#+END_SRC
+
+* HTML
+#+BEGIN_SRC html
+<!DOCTYPE html><html><head><title>Test</title></head><body><div class="container"><h1>Hello, World!</h1><p>This is a paragraph.</p></div></body></html>
+#+END_SRC
+
+* Vue
+#+BEGIN_SRC vue
+<template><div class="container"><h1>{{ title }}</h1><p>{{ message }}</p></div></template><script>export default{data(){return{title:"Hello, World!",message:"This is a Vue component"}}}</script><style>.container{width:100%;max-width:1200px;margin:0 auto;}</style>
+#+END_SRC
+
+* Markdown
+#+BEGIN_SRC markdown
+# Hello World
+
+This is a paragraph with *italic* and **bold** text.
+
+- Item 1
+-  Item 2
+-    Item 3
+
+```js
+function example(){console.log("This is a code block");}
+```
+#+END_SRC
+
+* YAML
+#+BEGIN_SRC yaml
+name:    John Doe
+age: 30
+isActive:    true
+address: {street: "123 Main St", city:    "Anytown",
+  zip:   "12345"}
+hobbies: [    "reading","coding",     "hiking"   ]
+#+END_SRC
+
+* GraphQL
+#+BEGIN_SRC graphql
+query GetUser{user(id:"123"){id name email posts{id title content}}}
+mutation CreatePost{createPost(title:"Hello",content:"World"){id title content}}
+#+END_SRC
+
+* Unrecognizable Language (for comparison)
+#+BEGIN_SRC unrecognizable-language
+function messy(a,b) { return a+b; }
+const obj = { foo: "bar", baz: 42 };
+if(true) { console.log("hello world"); }
+#+END_SRC

--- a/fixtures/clean.org
+++ b/fixtures/clean.org
@@ -1,0 +1,26 @@
+#+TITLE: Test Org File with Code Blocks
+
+* JavaScript Code Block
+#+BEGIN_SRC js
+function messy(a, b) {
+  return a + b;
+}
+
+const obj = {
+  foo: "bar",
+  baz: 42,
+  qux: "hello",
+};
+#+END_SRC
+
+* TypeScript Code Block
+#+BEGIN_SRC typescript
+interface Person {
+  name: string;
+  age: number;
+}
+
+function greet(person: Person) {
+  return "Hello, " + person.name;
+}
+#+END_SRC

--- a/fixtures/messy.org
+++ b/fixtures/messy.org
@@ -1,0 +1,26 @@
+#+TITLE: Test Org File with Code Blocks
+
+* JavaScript Code Block
+#+BEGIN_SRC js
+function messy(a,b)
+{
+return a+b;
+}
+
+const obj = {
+  foo: "bar",
+  baz:42,
+    qux:"hello"};
+#+END_SRC
+
+* TypeScript Code Block
+#+BEGIN_SRC typescript
+interface Person{
+  name:string;age:number
+}
+
+function greet(person:Person)
+{
+  return "Hello, "+person.name;
+}
+#+END_SRC

--- a/fixtures/unrecognizable.org
+++ b/fixtures/unrecognizable.org
@@ -1,0 +1,5 @@
+#+TITLE: Test Unrecognizable Language
+
+#+BEGIN_SRC unrecognizable-language
+function messy(a,b) { return a+b; }
+#+END_SRC

--- a/prettier-js-test.el
+++ b/prettier-js-test.el
@@ -467,5 +467,62 @@
     (let ((err (should-error (prettier-js-prettify-code-blocks) :type 'user-error)))
       (should (string= "Not in org-mode" (cadr err))))))
 
+(ert-deftest prettier-js-test-unrecognizable-language-blocks ()
+  "Test that prettier-js-prettify-code-blocks skips unrecognizable language blocks."
+  (let* ((unrecognizable-file (expand-file-name "fixtures/unrecognizable.org"))
+         (temp-file (make-temp-file "prettier-test-" nil ".org")))
+    (unwind-protect
+        (progn
+          ;; Copy unrecognizable content to temp file
+          (copy-file unrecognizable-file temp-file t)
+
+          ;; Visit the temp file
+          (with-current-buffer (find-file-noselect temp-file)
+            (org-mode)
+
+            ;; Remember the original content
+            (let ((original-content (buffer-string)))
+              ;; Format all code blocks
+              (prettier-js-prettify-code-blocks)
+
+              ;; Verify the content hasn't changed after formatting all blocks
+              (should (string= (buffer-string) original-content)))
+
+            (kill-buffer)))
+
+      ;; Clean up temp file
+      (when (file-exists-p temp-file)
+        (delete-file temp-file)))))
+
+(ert-deftest prettier-js-test-unrecognizable-language-block ()
+  "Test that prettier-js-prettify-code-block skips unrecognizable language blocks."
+  (let* ((unrecognizable-file (expand-file-name "fixtures/unrecognizable.org"))
+         (temp-file (make-temp-file "prettier-test-" nil ".org")))
+    (unwind-protect
+        (progn
+          ;; Copy unrecognizable content to temp file
+          (copy-file unrecognizable-file temp-file t)
+
+          ;; Visit the temp file
+          (with-current-buffer (find-file-noselect temp-file)
+            (org-mode)
+
+            ;; Remember the original content
+            (let ((original-content (buffer-string)))
+              ;; Try to format the specific unrecognizable block
+              (goto-char (point-min))
+              (search-forward "#+BEGIN_SRC unrecognizable-language")
+              (forward-line 1)
+              (prettier-js-prettify-code-block)
+
+              ;; Verify the content hasn't changed after trying to format the specific block
+              (should (string= (buffer-string) original-content)))
+
+            (kill-buffer)))
+
+      ;; Clean up temp file
+      (when (file-exists-p temp-file)
+        (delete-file temp-file)))))
+
 (provide 'prettier-js-test)
 ;;; prettier-js-test.el ends here

--- a/prettier-js.el
+++ b/prettier-js.el
@@ -369,14 +369,14 @@ Signal an error if not in org-mode."
       (while (re-search-forward "^[ \t]*#\\+begin_src\\s-+\\([a-zA-Z0-9]+\\)" nil t)
         (let* ((lang (match-string-no-properties 1))
                (block-start (line-beginning-position)))
-          (when (assoc lang prettier-js-language-to-extension)
-            (when (re-search-forward "^[ \t]*#\\+end_src" nil t)
-              (let* ((block-end (line-end-position))
-                     (element (save-restriction
-                                (narrow-to-region block-start block-end)
-                                (org-element-at-point))))
-                (setq count (1+ count))
-                (prettier-js--format-code-block element))))))
+          (when (and (assoc lang prettier-js-language-to-extension)
+                     (re-search-forward "^[ \t]*#\\+end_src" nil t))
+            (let* ((block-end (line-end-position))
+                   (element (save-restriction
+                              (narrow-to-region block-start block-end)
+                              (org-element-at-point))))
+              (setq count (1+ count))
+              (prettier-js--format-code-block element)))))
       (message "Formatted %d code block%s" count (if (= count 1) "" "s")))))
 
 (defun prettier-js-prettify-code-block ()
@@ -412,10 +412,10 @@ Signal an error if not within a code block."
                          (forward-line -1)
                          (point)))
          (lang (org-element-property :language element))
-         (ext (or (cdr (assoc lang prettier-js-language-to-extension))
-                  ".js"))             ; Default to js if language not recognized
-         (prettier-js-file-path (concat "temp" ext)))
-    (prettier-js--prettify contents-begin contents-end)))
+         (ext (cdr (assoc lang prettier-js-language-to-extension))))
+    (when ext
+      (let ((prettier-js-file-path (concat "temp" ext)))
+        (prettier-js--prettify contents-begin contents-end)))))
 
 (defvar prettier-js-mode-menu-map
   (let ((map (make-sparse-keymap "Prettier")))

--- a/prettier-js.el
+++ b/prettier-js.el
@@ -46,6 +46,8 @@
 (eval-when-compile
   (require 'org-element))
 
+(declare-function org-element-type "org-element-ast")
+
 (defgroup prettier-js nil
   "Minor mode to format JS code on file save"
   :group 'languages
@@ -387,7 +389,7 @@ Signal an error if not within a code block."
     (user-error "Not in org-mode"))
   (let ((element (org-element-at-point)))
     ;; Like (org-in-src-block-p t):
-    (unless (and (org-element-type-p element 'src-block)
+    (unless (and (eq (org-element-type element) 'src-block)
                  (not (or (<= (line-beginning-position)
                               (org-element-post-affiliated element))
                           (>= (line-end-position)

--- a/prettier-js.el
+++ b/prettier-js.el
@@ -393,7 +393,7 @@ Signal an error if not within a code block."
                  (not (or (<= (line-beginning-position)
                               (org-element-property :post-affiliated element))
                           (>= (line-end-position)
-                              (org-with-point-at (org-element-end element)
+                              (org-with-point-at (org-element-property :end element)
                                 (skip-chars-backward " \t\n\r")
                                 (point))))))
       (user-error "Not inside a source code block"))

--- a/prettier-js.el
+++ b/prettier-js.el
@@ -391,7 +391,7 @@ Signal an error if not within a code block."
     ;; Like (org-in-src-block-p t):
     (unless (and (eq (org-element-type element) 'src-block)
                  (not (or (<= (line-beginning-position)
-                              (org-element-post-affiliated element))
+                              (org-element-property :post-affiliated element))
                           (>= (line-end-position)
                               (org-with-point-at (org-element-end element)
                                 (skip-chars-backward " \t\n\r")


### PR DESCRIPTION
Now that we have support for formatting ranges of text in the buffer (https://github.com/prettier/prettier-emacs/pull/92), I used that to implement formatting of code blocks in `org-mode`.

You can simply do `M-x prettier-js-prettify` to format all the code blocks in an Org buffer; it will only format ones that Prettier can format.

You also move point inside a code block and do `M-x prettier-js-prettify-code-block` to format that one code block.

Fixes: https://github.com/prettier/prettier-emacs/issues/38

# Demo

https://github.com/user-attachments/assets/fd7f5c89-608c-4601-82c1-a1f89ce69ef0

https://github.com/user-attachments/assets/19fa4268-0ac0-4487-90ee-67d5870ec839