### PR TITLE
Broaden documentation

### DIFF
--- a/Eask
+++ b/Eask
@@ -2,7 +2,7 @@
 
 (package "prettier-js"
          "0.1.0"
-         "Minor mode to format JS code on file save")
+         "Minor mode to format code on file save")
 
 (website-url "https://github.com/prettier/prettier-emacs")
 (keywords "convenience" "wp" "edit" "js")

--- a/README.md
+++ b/README.md
@@ -141,6 +141,12 @@ If you want to mostly eliminate the overhead of running the `prettier` command o
 
 Note that this may come at the expense of a bit more complexity in terms of configuring/managing the daemon.
 
+## Available commands
+
+* `M-x prettier-js-prettify` formats the current buffer.  In `org-mode`, it formats all the code blocks in the buffer.
+* `M-x prettier-js-prettify-region` formats the current region
+* `M-x prettier-js-prettify-code-block` formats the code block at point (in `org-mode`)
+
 ## Customization
 
 This package is customizable via Emacs' easy customization interface:

--- a/README.md
+++ b/README.md
@@ -63,10 +63,10 @@ Or use `use-package` (available in Emacs 29.1 and above):
 (use-package prettier-js)
 ```
 
-Then you can hook into your favorite JavaScript mode:
+Then you can hook into any modes where you want to format with Prettier:
 
 ```elisp
-(add-hook 'js2-mode-hook 'prettier-js-mode)
+(add-hook 'js-mode-hook 'prettier-js-mode)
 (add-hook 'web-mode-hook 'prettier-js-mode)
 ```
 
@@ -88,8 +88,7 @@ Say that you only want to use Prettier with certain projects. Instead of configu
   (if (locate-dominating-file default-directory ".prettierrc")
       (prettier-js-mode +1)))
 
-(add-hook 'typescript-mode-hook 'maybe-use-prettier)
-(add-hook 'js2-mode-hook 'maybe-use-prettier)
+(add-hook 'js-mode-hook 'maybe-use-prettier)
 ```
 
 Alternatively, say that you want to use Prettier everywhere by default, except for when editing files in certain directories. Use `(add-hook 'some-mode-hook 'prettier-js-mode)`, and in directories where you want Prettier disabled, add a `.dir-locals.el` file with the following contents:

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 This Emacs package provides a function, `prettier-js-prettify`, which formats the current buffer using [Prettier](https://github.com/prettier/prettier). It also exports a minor mode, `prettier-js-mode`, which calls `prettier-js-prettify` on save.
 
+Despite the "-js" in its name, this package actually supports more than just JavaScript. It works with any language that Prettier supports! [List here.](https://prettier.io/docs/)
+
 ## Configuration
 
 ### Requirements

--- a/prettier-js-test.el
+++ b/prettier-js-test.el
@@ -421,7 +421,7 @@
 
     ;; Verify that the appropriate error is signaled with the correct message
     (let ((err (should-error (prettier-js-prettify-code-block) :type 'user-error)))
-      (should (string= "Not inside a source code block" (cadr err))))))
+      (should (string= "No source code block at point" (cadr err))))))
 
 (ert-deftest prettier-js-test-prettify-code-blocks ()
   "Test that prettier-js-prettify-code-blocks formats all code blocks in an org file."

--- a/prettier-js.el
+++ b/prettier-js.el
@@ -1,4 +1,4 @@
-;;; prettier-js.el --- Minor mode to format JS code on file save  -*- lexical-binding: t; -*-
+;;; prettier-js.el --- Minor mode to format code on file save  -*- lexical-binding: t; -*-
 
 ;; Copyright (c) 2014 The go-mode Authors. All rights reserved.
 ;; Portions Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
@@ -39,7 +39,7 @@
 ;; OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.)
 
 ;;; Commentary:
-;; Formats your JavaScript code using 'prettier' on file save.
+;; Formats your code using 'prettier' on file save.
 
 ;;; Code:
 
@@ -49,7 +49,7 @@
 (declare-function org-element-type "org-element-ast")
 
 (defgroup prettier-js nil
-  "Minor mode to format JS code on file save"
+  "Minor mode to format code on file save"
   :group 'languages
   :prefix "prettier-js"
   :link '(url-link :tag "Repository" "https://github.com/prettier/prettier"))

--- a/prettier-js.el
+++ b/prettier-js.el
@@ -429,15 +429,8 @@ Signal an error if not within a code block."
   (unless (derived-mode-p 'org-mode)
     (user-error "Not in org-mode"))
   (let ((element (org-element-at-point)))
-    ;; Like (org-in-src-block-p t):
-    (unless (and (eq (org-element-type element) 'src-block)
-                 (not (or (<= (line-beginning-position)
-                              (org-element-property :post-affiliated element))
-                          (>= (line-end-position)
-                              (org-with-point-at (org-element-property :end element)
-                                (skip-chars-backward " \t\n\r")
-                                (point))))))
-      (user-error "Not inside a source code block"))
+    (unless (eq (org-element-type element) 'src-block)
+      (user-error "No source code block at point"))
     (prettier-js--format-code-block element)))
 
 (defun prettier-js--format-code-block (element)


### PR DESCRIPTION
Based on the support that was requested in https://github.com/prettier/prettier-emacs/issues/45, I figured it might be helpful if the documentation didn't suggest hooking into JS modes that don't come pre-installed with Emacs.

Regarding JS modes, I figured this would also be a good time to clarify that Prettier (and thus this package) isn't limited to just JavaScript any more.

Almost-related is that I mentioned in the README how this package also works with Org.  Even more tangential is that I realized the documentation for `prettier-js-prettify-code-block` could be simplified if I made it properly check for the code block "at point," so I made that little update too.