### PR TITLE
Path errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ This package uses the `diff` program under the hood to reliably identify formatt
      (Use the appropriate command name for your system, which might be `gdiff`, `gnudiff`, or `gd`)
 </details>
 
+#### Ensure Emacs' path is configured correctly
+
+Depending on how the programs are installed, `node`, `prettier`, and/or `diff` may be missing on Emacs' `exec-path`.  When attempting to format a buffer, this could result in errors such as:
+
+- "Node executable not found"
+- "Could not find prettier executable"
+
+An easy solution to this issue is to install and use [`exec-path-from-shell`](https://github.com/purcell/exec-path-from-shell).  Add to your init file:
+
+```elisp
+(exec-path-from-shell-initialize)
+```
+
 ### Basic configuration
 
 First require the package:

--- a/prettier-js-test.el
+++ b/prettier-js-test.el
@@ -167,7 +167,7 @@
           (with-current-buffer (find-file-noselect temp-file)
             ;; Verify that the appropriate error is signaled with the correct message
             (let ((err (should-error (prettier-js-prettify) :type 'user-error)))
-              (should (string= "Could not find prettier executable" (cadr err))))
+              (should (string-match-p "Could not find prettier executable" (cadr err))))
             (kill-buffer)))
 
       ;; Clean up temp file
@@ -211,7 +211,7 @@
           (with-current-buffer (find-file-noselect temp-file)
             ;; Verify that the appropriate error is signaled with the correct message
             (let ((err (should-error (prettier-js-prettify) :type 'user-error)))
-              (should (string= "Could not find diff executable" (cadr err))))
+              (should (string-match-p "Could not find diff executable" (cadr err))))
             (kill-buffer)))
 
       ;; Clean up temp file

--- a/prettier-js.el
+++ b/prettier-js.el
@@ -246,7 +246,7 @@ Signals an error if the executable cannot be found."
           (setq prettier-js-error-state nil)
           prettier-js-command)
       (setq prettier-js-error-state "Prettier executable not found")
-      (user-error "Could not find prettier executable"))))
+      (user-error "Could not find prettier executable; is it installed and on Emacs' exec-path?"))))
 
 (defun prettier-js--get-diff-command ()
   "Get the diff command to use.
@@ -257,7 +257,7 @@ Signals an error if the executable cannot be found."
         (setq prettier-js-error-state nil)
         prettier-js-diff-command)
     (setq prettier-js-error-state "Diff executable not found")
-    (user-error "Could not find diff executable")))
+    (user-error "Could not find diff executable; is it installed and on Emacs' exec-path?")))
 
 (defvar prettier-js-file-path nil
   "Override file path for prettier.

--- a/prettier-js.el
+++ b/prettier-js.el
@@ -153,7 +153,7 @@ When non-nil, contains the error message to display.")
               (error "Invalid rcs patch or internal error in prettier-js--apply-rcs-patch")))))))))
 
 (defconst prettier-js--error-explanations
-  '(("env: node: No such file or directory" . "Could not find node executable; is it on Emacs' exec-path?"))
+  '(("env: node: No such file or directory" . ("Node executable not found" "Could not find node executable; is it on Emacs' exec-path?")))
   "Alist mapping error patterns to user-friendly error messages.")
 
 (defun prettier-js--get-error-explanation (error-content)
@@ -186,7 +186,9 @@ When non-nil, contains the error message to display.")
                           (buffer-string)))
          (explanation (prettier-js--get-error-explanation error-content)))
     (if explanation
-        (user-error explanation)
+        (progn
+          (setq prettier-js-error-state (car explanation))
+          (user-error (cadr explanation)))
       (message "Could not apply prettier")
       (when errbuf
         (prettier-js--show-error-buffer filename errorfile errbuf)))))


### PR DESCRIPTION
As in https://github.com/prettier/prettier-emacs/issues/63, users often encounter path configuration-related issues.  Especially with Node, which is often installed and managed by different version/package managers, those of which don't always put `node` in a "standard" directory like `/usr/local/bin`.

Try to provide a helpful suggestion on how to configure the path in the readme.  Also try to clue the user into investigating path issues when it seems like an executable can't be found.

# Demo

https://github.com/user-attachments/assets/22f31378-e2e4-471a-b41b-dcd424355eb8

