### PR TITLE
ci: declare contents:read on test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Pins `.github/workflows/test.yml` to `permissions: contents: read` at the workflow level. The CI job sets up Node and Emacs, installs the package locally, then runs the prettier integration tests against the Emacs binary. No GitHub API calls beyond the initial checkout.

CVE-2025-30066 (the March 2025 `tj-actions/changed-files` compromise) is the supply-chain case for being explicit: a tampered third-party action read `GITHUB_TOKEN` from workflow logs and the blast radius equalled whatever scope was issued. Capping at `contents: read` here keeps the runtime authority bounded regardless of the org or repo default, gives drift protection if that default ever widens, and registers with OpenSSF Scorecard's Token-Permissions check.

YAML validated locally with `yaml.safe_load`.
